### PR TITLE
feat: add post callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,36 @@ recurse(
 
 See the [log-spec.js](./cypress/integration/log-spec.js)
 
+### post
+
+If you want to run a few more Cypress commands after the predicate function that are not part of the initial command, use the `post` option. For example, you can start intercepting the network requests after a few iterations:
+
+```js
+// from the application's window ping a non-existent URL
+const url = 'https://jsonplaceholder.cypress.io/fake-endpoint'
+const checkApi = () => cy.window().invoke('fetch', url)
+const isSuccess = ({ ok }) => ok
+
+recurse(checkApi, isSuccess, {
+  post: ({ limit }) => {
+    // after a few attempts
+    // stub the network call and respond
+    if (limit === 1) {
+      // start intercepting now
+      console.log('start intercepting')
+      return cy.intercept('GET', url, 'Hello!').as('hello')
+    }
+  },
+})
+```
+
+See the [post-spec.js](./cypress/integration/post-spec.js)
+
 ## Examples
 
 - [avoid-while-loops-in-cypress](https://github.com/bahmutov/avoid-while-loops-in-cypress) repo
-- [monalego](https://github.com/bahmutov/monalego) repo and [Canvas Visual Testing with Retries](https://glebbahmutov.com/blog/canvas-testing/) blog post
+- [monalego](https://github.com/bahmutov/monalego) repo and [Canvas Visual Testing with Retries](https://glebbahmutov.com/blog/canvas-testing/) blog post, watch [the video](https://www.youtube.com/watch?v=xSK6fe5WD1g)
 - [reloading the page until it shows the expected text](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/testing-dom__page-reloads) recipe
-
 
 ## Blog post
 

--- a/cypress/integration/post-spec.js
+++ b/cypress/integration/post-spec.js
@@ -1,0 +1,36 @@
+// @ts-check
+/// <reference types="cypress" />
+import { recurse } from '../../src'
+
+describe('extra commands option', () => {
+  it('can run extra cy commands between iterations', () => {
+    // from the application's window ping a non-existent URL
+    const url = 'https://jsonplaceholder.cypress.io/fake-endpoint'
+    const checkApi = () => cy.window().invoke('fetch', url)
+    const isSuccess = ({ ok }) => ok
+
+    recurse(checkApi, isSuccess, {
+      limit: 2,
+      delay: 1000,
+      log: (r) => cy.log(`response **${r.status}**`),
+      post: ({ limit }) => {
+        // after a few attempts
+        // stub the network call and respond
+        console.log('post: limit %d', limit)
+
+        if (limit === 1) {
+          // start intercepting now
+          console.log('start intercepting')
+          return cy.intercept('GET', url, 'Hello!').as('hello')
+        }
+      },
+    })
+      // the "checkApi" chain yields the fetch response
+      .invoke('text')
+      // which should equal our stub
+      .should('equal', 'Hello!')
+
+    // confirm the intercept works
+    cy.get('@hello')
+  })
+})

--- a/cypress/integration/post-spec.js
+++ b/cypress/integration/post-spec.js
@@ -33,4 +33,32 @@ describe('extra commands option', () => {
     // confirm the intercept works
     cy.get('@hello')
   })
+
+  it('starts stubbing a method', () => {
+    const obj = {
+      greeting() {
+        return 'not yet'
+      },
+    }
+    recurse(
+      () => cy.wrap(obj.greeting()),
+      (s) => s === 'ready!',
+      {
+        limit: 5,
+        delay: 500,
+        post({ limit }) {
+          if (limit === 3) {
+            cy.stub(obj, 'greeting').returns('ready!')
+          }
+        },
+      },
+    )
+      .should('equal', 'ready!')
+      // the stub was created and called
+      .then(() => {
+        // and really was called just once
+        // before the recursion has finished
+        expect(obj.greeting).to.have.been.calledOnce
+      })
+  })
 })


### PR DESCRIPTION
If you want to run additional Cypress commands between the iterations

```js
recurse(
  () => cy.wrap(obj.greeting()),
  (s) => s === 'ready!',
  {
    limit: 5,
    delay: 500,
    post({ limit }) {
      if (limit === 3) {
        cy.stub(obj, 'greeting').returns('ready!')
      }
    },
  },
)
```

Since the predicate cannot have Cypress commands