### PR TITLE
TS: return Chainable type generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ If you want to run a few more Cypress commands after the predicate function that
 // from the application's window ping a non-existent URL
 const url = 'https://jsonplaceholder.cypress.io/fake-endpoint'
 const checkApi = () => cy.window().invoke('fetch', url)
-const isSuccess = ({ ok }) => ok
 
-recurse(checkApi, isSuccess, {
+recurse(checkApi, ({ ok }) => ok, {
   post: ({ limit }) => {
     // after a few attempts
     // stub the network call and respond

--- a/cypress/integration/post-spec.js
+++ b/cypress/integration/post-spec.js
@@ -6,11 +6,10 @@ describe('extra commands option', () => {
   it('can run extra cy commands between iterations', () => {
     // from the application's window ping a non-existent URL
     const url = 'https://jsonplaceholder.cypress.io/fake-endpoint'
-    const checkApi = () => cy.window().invoke('fetch', url)
-    // @ts-ignore
-    const isSuccess = ({ ok }) => ok
 
-    recurse(checkApi, isSuccess, {
+    const checkApi = () => cy.request(url)
+    
+    recurse(checkApi, ({ status }) => status >= 200 && status < 500, {
       limit: 2,
       delay: 1000,
       log: (r) => cy.log(`response **${r.status}**`),

--- a/cypress/integration/post-spec.js
+++ b/cypress/integration/post-spec.js
@@ -7,9 +7,9 @@ describe('extra commands option', () => {
     // from the application's window ping a non-existent URL
     const url = 'https://jsonplaceholder.cypress.io/fake-endpoint'
 
-    const checkApi = () => cy.request({ url, failOnStatusCode: false })
+    const checkApi = () => cy.window().invoke('fetch', url)
     
-    recurse(checkApi, ({ status }) => status >= 200 && status < 500, {
+    recurse(checkApi, ({ ok }) => ok, {
       limit: 2,
       delay: 1000,
       log: (r) => cy.log(`response **${r.status}**`),

--- a/cypress/integration/post-spec.js
+++ b/cypress/integration/post-spec.js
@@ -7,7 +7,7 @@ describe('extra commands option', () => {
     // from the application's window ping a non-existent URL
     const url = 'https://jsonplaceholder.cypress.io/fake-endpoint'
 
-    const checkApi = () => cy.request(url)
+    const checkApi = () => cy.request({ url, failOnStatusCode: false })
     
     recurse(checkApi, ({ status }) => status >= 200 && status < 500, {
       limit: 2,

--- a/cypress/integration/typecheck.js
+++ b/cypress/integration/typecheck.js
@@ -7,4 +7,9 @@ describe('typechecking', () => {
         /** @type {Cypress.Chainable<number>} */
         const isNumber = recurse(() => cy.wrap(1), (x) => x === 1).should('be.equal', 1)
     })
+
+    it('correctly infers the type of a promise', () => {
+        /** @type {Cypress.Chainable<number>} */
+        const isNumber = recurse(() => cy.wrap(Promise.resolve(1)), (x) => x === 1).should('be.equal', 1)
+    })
 })

--- a/cypress/integration/typecheck.js
+++ b/cypress/integration/typecheck.js
@@ -1,0 +1,10 @@
+// @ts-check
+/// <reference types="cypress" />
+import { recurse } from '../../src'
+
+describe('typechecking', () => {
+    it('correctly infers the type from the return value', () => {
+        /** @type {Cypress.Chainable<number>} */
+        const isNumber = recurse(() => cy.wrap(1), (x) => x === 1).should('be.equal', 1)
+    })
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-export type LogOption = boolean | string | ((arg0: any) => void)
+export type LogOption<T> = boolean | string | ((arg: T) => void)
 
 interface PostFunctionOptions {
   /**
@@ -11,7 +11,7 @@ interface PostFunctionOptions {
 
 type PostFunction = (opts: PostFunctionOptions) => void | Cypress.Chainable
 
-interface RecurseOptions {
+interface RecurseOptions<T> {
   /**
    * The max number of iterations
    */
@@ -25,7 +25,7 @@ interface RecurseOptions {
    * a message to be printed once at the end,
    * or a custom function
    */
-  log: LogOption
+  log: LogOption<T>
   /**
    * Between iterations, milliseconds
    */
@@ -57,7 +57,7 @@ interface RecurseOptions {
  export function recurse<T>(
   commandsFn: () => Cypress.Chainable<T>,
   checkFn: (x: T) => boolean | void | Chai.Assertion,
-  options?: Partial<RecurseOptions>,
+  options?: Partial<RecurseOptions<T>>,
 ): Cypress.Chainable<T>
 
-export const RecurseDefaults: RecurseOptions
+export const RecurseDefaults: RecurseOptions<any>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,12 +54,10 @@ interface RecurseOptions {
  * @param checkFn Predicate that should return true to finish
  * @param options Options for maximum timeout, logging, etc
  */
-type RecurseFn = (
-  commandsFn: () => Cypress.Chainable,
-  checkFn: (x: any) => boolean | void | Chai.Assertion,
+ export function recurse<T>(
+  commandsFn: () => Cypress.Chainable<T>,
+  checkFn: (x: T) => boolean | void | Chai.Assertion,
   options?: Partial<RecurseOptions>,
-) => Cypress.Chainable
+): Cypress.Chainable<T>
 
 export const RecurseDefaults: RecurseOptions
-
-export const recurse: RecurseFn

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,6 +55,12 @@ interface RecurseOptions<T> {
  * @param options Options for maximum timeout, logging, etc
  */
  export function recurse<T>(
+  commandsFn: () => Cypress.Chainable<Promise<T>>,
+  checkFn: (x: T) => boolean | void | Chai.Assertion,
+  options?: Partial<RecurseOptions<T>>,
+): Cypress.Chainable<T>
+
+export function recurse<T>(
   commandsFn: () => Cypress.Chainable<T>,
   checkFn: (x: T) => boolean | void | Chai.Assertion,
   options?: Partial<RecurseOptions<T>>,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,13 +55,7 @@ interface RecurseOptions<T> {
  * @param options Options for maximum timeout, logging, etc
  */
  export function recurse<T>(
-  commandsFn: () => Cypress.Chainable<Promise<T>>,
-  checkFn: (x: T) => boolean | void | Chai.Assertion,
-  options?: Partial<RecurseOptions<T>>,
-): Cypress.Chainable<T>
-
-export function recurse<T>(
-  commandsFn: () => Cypress.Chainable<T>,
+  commandsFn: () => Cypress.Chainable<Promise<T> | T>,
   checkFn: (x: T) => boolean | void | Chai.Assertion,
   options?: Partial<RecurseOptions<T>>,
 ): Cypress.Chainable<T>

--- a/src/index.js
+++ b/src/index.js
@@ -17,22 +17,6 @@ const RecurseDefaults = {
 /**
  * @template T
  * @type {RecurseFn<T>}
- * 
- * @variation 1
- * @param {() => Cypress.Chainable<Promise<T>>} commandsFn
- * @param {(x: T) => boolean | void | Chai.Assertion} checkFn
- * @param {Partial<RecurseOptions<T>>} options
- * 
- * @returns {Cypress.Chainable<T>}
- * 
- *//**
- * 
- * @variation 2
- * @param {() => Cypress.Chainable<T>} commandsFn
- * @param {(x: T) => boolean | void | Chai.Assertion} checkFn
- * @param {Partial<RecurseOptions<T>>} options
- * 
- * @returns {Cypress.Chainable<T>}
  */
 function recurse(commandsFn, checkFn, options = {}) {
   return cy.then(function cypressRecurse() {
@@ -115,15 +99,21 @@ function recurse(commandsFn, checkFn, options = {}) {
         ].join(' '),
       )
     }
-    return result.then(function cypressRecurse(x) {
+    
+    return result.then(
+      /** @param {T} x */
+      // @ts-ignore
+      function cypressRecurse(x) {
       if (logCommands) {
         // @ts-ignore
         cy.log(x)
       } else if (typeof options.log === 'function') {
+        // @ts-ignore
         options.log(x)
       }
 
       try {
+        // @ts-ignore
         const predicateResult = checkFn(x)
         // treat truthy as success and stop the recursion
         if (

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,29 @@ const RecurseDefaults = {
 }
 
 /**
- * @type {import('./index').recurse<any>}
+ * @template T
+ * @typedef {import('./index').RecurseOptions<T>} RecurseOptions<T>
+ * @typedef {import('./index').recurse<T>} RecurseFn<T>
+ */
+
+/**
+ * @template T
+ * @type {RecurseFn<T>}
+ * 
+ * @variation 1
+ * @param {() => Cypress.Chainable<Promise<T>>} commandsFn
+ * @param {(x: T) => boolean | void | Chai.Assertion} checkFn
+ * @param {Partial<RecurseOptions<T>>} options
+ * 
+ * @returns {Cypress.Chainable<T>}
+ * 
+ *//**
+ * @variation 2
+ * @param {() => Cypress.Chainable<T>} commandsFn
+ * @param {(x: T) => boolean | void | Chai.Assertion} checkFn
+ * @param {Partial<RecurseOptions<T>>} options
+ * 
+ * @returns {Cypress.Chainable<T>}
  */
 function recurse(commandsFn, checkFn, options = {}) {
   return cy.then(function cypressRecurse() {

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ const RecurseDefaults = {
  * @returns {Cypress.Chainable<T>}
  * 
  *//**
+ * 
  * @variation 2
  * @param {() => Cypress.Chainable<T>} commandsFn
  * @param {(x: T) => boolean | void | Chai.Assertion} checkFn

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const RecurseDefaults = {
 }
 
 /**
- * @type {import('./index').RecurseFn}
+ * @type {import('./index').recurse<any>}
  */
 function recurse(commandsFn, checkFn, options = {}) {
   return cy.then(function cypressRecurse() {
@@ -94,6 +94,7 @@ function recurse(commandsFn, checkFn, options = {}) {
     }
     return result.then(function cypressRecurse(x) {
       if (logCommands) {
+        // @ts-ignore
         cy.log(x)
       } else if (typeof options.log === 'function') {
         options.log(x)


### PR DESCRIPTION
Updates the typescript definitions to properly set the `Chainable` return type to the return of the `commandsFn`. Contains no changes to the actual functionality of the library.

While technically possible for people that are using it to start getting TS complains following this change, that would only be if their tests are already borked. It just takes the return value from the `commandsFn` and sets it as the returned `Chainable` type, rather than the return type always being `any`.