### PR TITLE
fix: handle empty objects returned from the command

### DIFF
--- a/cypress/integration/back-button/app.js
+++ b/cypress/integration/back-button/app.js
@@ -1,0 +1,20 @@
+let currentPage = 4
+
+function renderPage() {
+  document.getElementById('page').innerText = currentPage
+  if (currentPage > 0) {
+    document.getElementById('controls').innerHTML = `
+      <button id="back">Back</button>
+    `
+  } else {
+    document.getElementById('controls').innerHTML = ''
+  }
+}
+
+renderPage()
+document.addEventListener('click', (event) => {
+  if (event.target.id === 'back') {
+    currentPage--
+    renderPage()
+  }
+})

--- a/cypress/integration/back-button/index.html
+++ b/cypress/integration/back-button/index.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>Back Button</title>
+  </head>
+  <body>
+    <h1>Back button</h1>
+    <div>Current page <span id="page"></span></div>
+    <div id="controls"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/cypress/integration/back-button/spec.js
+++ b/cypress/integration/back-button/spec.js
@@ -3,13 +3,24 @@
 import { recurse } from '../../..'
 
 describe('Back button', { viewportHeight: 200, viewportWidth: 300 }, () => {
+  it('cannot use cy.wrap with an empty jQuery object', () => {
+    // by default, cy.wrap expected jQuery object to exist
+    // cy.wrap(Cypress.$())
+    // we can disable the built-in element existence check
+    // by attaching our own no-op should callback
+    cy.wrap(Cypress.$()).should(Cypress._.noop)
+  })
+
   it('goes from the last page to the first', () => {
     cy.visit('cypress/integration/back-button/index.html')
     // click on the "Back" button until the we get to the first page
     // and the button is gone from the DOM
     recurse(
       () => cy.get('#back').should(Cypress._.noop),
-      ($button) => $button.length === 0,
+      // our predicate can check if the jQuery element is empty
+      // using its "length" property or the Lodash _.isEmpty function
+      // ($button) => $button.length === 0,
+      Cypress._.isEmpty,
       {
         post() {
           cy.get('#back').click()
@@ -19,5 +30,7 @@ describe('Back button', { viewportHeight: 200, viewportWidth: 300 }, () => {
         limit: 10,
       },
     )
+      // check if the "Back" button is gone from the DOM
+      .should('not.exist')
   })
 })

--- a/cypress/integration/back-button/spec.js
+++ b/cypress/integration/back-button/spec.js
@@ -1,0 +1,23 @@
+// @ts-check
+/// <reference path="../../../src/index.d.ts" />
+import { recurse } from '../../..'
+
+describe('Back button', { viewportHeight: 200, viewportWidth: 300 }, () => {
+  it('goes from the last page to the first', () => {
+    cy.visit('cypress/integration/back-button/index.html')
+    // click on the "Back" button until the we get to the first page
+    // and the button is gone from the DOM
+    recurse(
+      () => cy.get('#back').should(Cypress._.noop),
+      ($button) => $button.length === 0,
+      {
+        post() {
+          cy.get('#back').click()
+        },
+        delay: 1000,
+        timeout: 10000,
+        limit: 10,
+      },
+    )
+  })
+})


### PR DESCRIPTION
fixes #75

Sometimes we expect to iterate until the object is no longer there, and this fix lets you pass the empty jQuery object from the recurse function without the built-in existence assertion in the `cy.wrap`

For example, clicking on the "Back" button until it no longer exists

```js
it('goes from the last page to the first', () => {
  cy.visit('cypress/integration/back-button/index.html')
  // click on the "Back" button until the we get to the first page
  // and the button is gone from the DOM
  recurse(
    () => cy.get('#back').should(Cypress._.noop),
    // our predicate can check if the jQuery element is empty
    // using its "length" property or the Lodash _.isEmpty function
    // ($button) => $button.length === 0,
    Cypress._.isEmpty,
    {
      post() {
        cy.get('#back').click()
      },
      delay: 1000,
      timeout: 10000,
      limit: 10,
    },
  )
    // check if the "Back" button is gone from the DOM
    .should('not.exist')
})
```