### PR TITLE
feat: add each function

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,41 @@ recurse(
 )
 ```
 
+## each
+
+This plugin also includes the `each` function that iterates over the given subject items. It can optionally stop when the separate predicate function returns true.
+
+```js
+import { each } from 'cypress-recurse'
+it('iterates until it finds the value 7', () => {
+  cy.get('li').then(
+    each(
+      $li => ..., // do something with the item
+      $li => $li.text() === '7' // stop if we see "7"
+    )
+  )
+})
+```
+
+The `each` function yields the original or transformed items
+
+```js
+const numbers = [1, 2, 3, 4]
+cy.wrap(numbers)
+  .then(
+    each(
+      (x) => {
+        return 10 + x
+      },
+      // stop when the value is 13
+      (x) => x === 13,
+    ),
+  )
+  .should('deep.equal', [11, 12])
+```
+
+See the [each-spec.js](./cypress/integration/each/each-spec.js) file.
+
 ## Examples
 
 - clear and type text into the input field until it has the expected value, see [type-with-retries-spec.js](./cypress/integration/type-with-retries-spec.js), watch the video [Avoid Flake When Typing Into The Input Elements Using cypress-recurse](https://youtu.be/aYX7OVqp6AE) and read the blog post [Solve Flake In Cypress Typing Into An Input Element

--- a/cypress/integration/each/app.js
+++ b/cypress/integration/each/app.js
@@ -1,0 +1,12 @@
+document
+  .querySelector('table tbody')
+  .addEventListener('click', function (event) {
+    if (event.target.nodeName === 'BUTTON') {
+      // set the text in the next cell, but after async delay
+      // to make sure we write a flake-free test that retries
+      setTimeout(function () {
+        const cell = event.target.parentElement.parentElement.children[1]
+        cell.innerText = Math.random().toString().substr(2, 1)
+      }, 1000)
+    }
+  })

--- a/cypress/integration/each/each-spec.js
+++ b/cypress/integration/each/each-spec.js
@@ -1,0 +1,107 @@
+// @ts-check
+/// <reference path="../../../src/index.d.ts" />
+// in the user's code this import would be
+// import { each } from 'cypress-recurse'
+import { each } from '../../../src'
+
+describe('each', { viewportWidth: 200 }, () => {
+  it('iterates over each row until it finds number 7', () => {
+    cy.visit('cypress/integration/each/index.html')
+    cy.get('#lotto tbody tr button')
+      .should('have.length.greaterThan', 10)
+      .then(
+        each(
+          ($button) => {
+            cy.wrap($button, { log: false })
+              .click()
+              // once the button is clicked,
+              // find the text in the cell next to it
+              .parent() // <TD>
+              .parent() // <TR>
+              .find('td')
+              .eq(1) // <TD> with the number
+              .should(($td) => expect($td.text()).to.match(/\d/))
+          },
+          ($td) => $td.text() === '7',
+        ),
+      )
+  })
+
+  it('iterates over every row', () => {
+    cy.visit('cypress/integration/each/index.html')
+    cy.get('#lotto tbody tr')
+      .should('have.length.greaterThan', 10)
+      .its('length')
+      .then((n) => {
+        let count = 0
+        cy.get('#lotto tbody tr button')
+          .then(
+            each(($button) => {
+              count += 1
+              cy.wrap($button).click().wait(500, { log: false })
+            }),
+          )
+          .then(() => {
+            expect(count, 'number of calls').to.equal(n)
+          })
+      })
+  })
+
+  it('yields the values in a new array', () => {
+    const numbers = [1, 2, 3, 4]
+    cy.wrap(numbers)
+      .then(
+        each((x) => {
+          cy.log(x)
+        }),
+      )
+      .should('deep.equal', numbers)
+      .and('not.equal', numbers)
+  })
+
+  it('yields the values iterated over', () => {
+    const numbers = [1, 2, 3, 4]
+    cy.wrap(numbers)
+      .then(
+        each(
+          (x) => {
+            cy.log(x)
+          },
+          // stop when the value is 3
+          (x) => x === 3,
+        ),
+      )
+      .should('deep.equal', [1, 2])
+  })
+
+  it('can change the value using commands', () => {
+    const numbers = [1, 2, 3, 4]
+    cy.wrap(numbers)
+      .then(
+        each(
+          (x) => {
+            cy.log(x)
+            cy.wrap(10 + x)
+          },
+          // stop when the value is 13
+          (x) => x === 13,
+        ),
+      )
+      .should('deep.equal', [11, 12])
+  })
+
+  it('can change the value using return', () => {
+    const numbers = [1, 2, 3, 4]
+    cy.wrap(numbers)
+      .then(
+        each(
+          (x) => {
+            return 10 + x
+          },
+          // stop when the value is 13
+          (x) => x === 13,
+        ),
+      )
+      .should('deep.equal', [11, 12])
+  })
+})

--- a/cypress/integration/each/index.html
+++ b/cypress/integration/each/index.html
@@ -1,0 +1,77 @@
+<html>
+  <body>
+    <table id="lotto">
+      <thead>
+        <th>Pick This</th>
+        <th>Number</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+        <tr>
+          <td><button>Click me</button></td>
+          <td>???</td>
+        </tr>
+      </tbody>
+    </table>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,7 +54,7 @@ interface RecurseOptions<T> {
  * @param checkFn Predicate that should return true to finish
  * @param options Options for maximum timeout, logging, etc
  */
- export function recurse<T>(
+export function recurse<T>(
   commandsFn: () => Cypress.Chainable<Promise<T>>,
   checkFn: (x: T) => boolean | void | Chai.Assertion,
   options?: Partial<RecurseOptions<T>>,
@@ -67,3 +67,23 @@ export function recurse<T>(
 ): Cypress.Chainable<T>
 
 export const RecurseDefaults: RecurseOptions<any>
+
+export function each<T>(
+  commandsFn: (x: T) => Cypress.Chainable<Promise<T>>,
+  checkFn?: (x: T) => boolean | void | Chai.Assertion,
+): Cypress.Chainable<T[]>
+
+export function each<T>(
+  commandsFn: (x: T) => Cypress.Chainable<T>,
+  checkFn?: (x: T) => boolean | void | Chai.Assertion,
+): Cypress.Chainable<T>
+
+export function each(
+  commandsFn: (x: any) => any | Cypress.Chainable<any>,
+  checkFn?: (x: any) => boolean | void | Chai.Assertion,
+): any | Cypress.Chainable<any | void | null>
+
+export function each(
+  commandsFn: (x: any) => any,
+  checkFn?: (x: any) => boolean | void | Chai.Assertion,
+): Cypress.Chainable<any | void | null>


### PR DESCRIPTION
This plugin also includes the `each` function that iterates over the given subject items. It can optionally stop when the separate predicate function returns true.

```js
import { each } from 'cypress-recurse'
it('iterates until it finds the value 7', () => {
  cy.get('li').then(
    each(
      $li => ..., // do something with the item
      $li => $li.text() === '7' // stop if we see "7"
    )
  )
})
```

The `each` function yields the original or transformed items

```js
const numbers = [1, 2, 3, 4]
cy.wrap(numbers)
  .then(
    each(
      (x) => {
        return 10 + x
      },
      // stop when the value is 13
      (x) => x === 13,
    ),
  )
  .should('deep.equal', [11, 12])
```