### PR TITLE
feat: add elapsed value to the post argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ recurse(checkApi, ({ ok }) => ok, {
 })
 ```
 
-The argument is a single object with `limit`, `value`, and `reduced` properties.
+The argument is a single object with `limit`, `value`, `reduced`, and `elapsed` properties.
 
 See the [post-spec.js](./cypress/integration/post-spec.js) and [find-on-page/spec.js](./cypress/integration/find-on-page/spec.js).
 

--- a/cypress/integration/post-spec.js
+++ b/cypress/integration/post-spec.js
@@ -105,4 +105,24 @@ describe('extra commands option', () => {
       },
     )
   })
+
+  it('passes the elapsed duration since the recurse start', () => {
+    const list = ['first', 'second', 'third']
+    recurse(
+      () => {
+        const s = list.shift()
+        return cy.wrap(s)
+      },
+      (s) => s === 'third',
+      {
+        post({ elapsed }) {
+          expect(elapsed, 'elapsed').to.be.greaterThan(0)
+          cy.log(`elapsed ${elapsed}ms`)
+        },
+        limit: 3,
+        delay: 500,
+        log: false,
+      },
+    )
+  })
 })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,10 @@ interface PostFunctionOptions<T> {
    * The current reduced value, if any
    */
   reduced: any
+  /**
+   * Time since the recursion started, ms
+   */
+  elapsed: number
 }
 
 type PostFunction<T> = (
@@ -84,13 +88,19 @@ interface RecurseOptions<T> {
  */
 export function recurse<T>(
   commandsFn: () => Cypress.Chainable<Promise<T>>,
-  checkFn: (x: T, reducedValue?: any) => boolean | void | Chai.Assertion,
+  checkFn: (
+    x: T,
+    reducedValue?: any,
+  ) => boolean | void | Chai.Assertion,
   options?: Partial<RecurseOptions<T>>,
 ): Cypress.Chainable<T>
 
 export function recurse<T>(
   commandsFn: () => Cypress.Chainable<T>,
-  checkFn: (x: T, reducedValue?: any) => boolean | void | Chai.Assertion,
+  checkFn: (
+    x: T,
+    reducedValue?: any,
+  ) => boolean | void | Chai.Assertion,
   options?: Partial<RecurseOptions<T>>,
 ): Cypress.Chainable<T>
 

--- a/src/index.js
+++ b/src/index.js
@@ -260,10 +260,12 @@ function recurse(commandsFn, checkFn, options = {}) {
           })
           .then(() => {
             if (typeof options.post === 'function') {
+              const elapsed = +new Date() - options.started
               const result = options.post({
                 limit: options.limit,
                 value: x,
                 reduced: options.reduceFrom,
+                elapsed,
               })
               return Cypress.isCy(result) ? result : cy
             }


### PR DESCRIPTION
```js
post({ elapsed }) {
  // elapsed is in ms
}
```