### PR TITLE
feat: yield the last value

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,18 @@ recurse(commandFn, predicate, {
 })
 ```
 
-The yielded value in this case is not guaranteed
+The yielded value in this case is not guaranteed. You can yield the last value, even if it does not pass the predicate by explicitly asking for it
+
+```js
+recurse(
+  () => cy.wrap(4),
+  (x) => x === 10,
+  {
+    doNotFail: true,
+    yield: 'value',
+  },
+).should('equal', 4)
+```
 
 ## each
 

--- a/cypress/e2e/do-not-fail-spec.js
+++ b/cypress/e2e/do-not-fail-spec.js
@@ -23,13 +23,25 @@ describe('do not fail option', () => {
 
   context('yields value', () => {
     // https://github.com/bahmutov/cypress-recurse/issues/157
-    it.skip('even if predicate is false', () => {
+    it('even if predicate is false', () => {
       recurse(getTo(3), (x) => x === 100, {
         doNotFail: true,
         yield: 'value',
         limit: 3,
         delay: 100,
       }).should('equal', 3)
+    })
+
+    it('yields the value', () => {
+      recurse(
+        () => cy.wrap(4),
+        (x) => x === 10,
+        {
+          doNotFail: true,
+          yield: 'value',
+          limit: 1,
+        },
+      ).should('equal', 4)
     })
   })
 })

--- a/cypress/e2e/do-not-fail-spec.js
+++ b/cypress/e2e/do-not-fail-spec.js
@@ -20,4 +20,16 @@ describe('do not fail option', () => {
       timeout: 1000,
     }).should('be.undefined')
   })
+
+  context('yields value', () => {
+    // https://github.com/bahmutov/cypress-recurse/issues/157
+    it.skip('even if predicate is false', () => {
+      recurse(getTo(3), (x) => x === 100, {
+        doNotFail: true,
+        yield: 'value',
+        limit: 3,
+        delay: 100,
+      }).should('equal', 3)
+    })
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,10 @@ function recurse(commandsFn, checkFn, options = {}) {
       iteration: 1,
       reduce: Cypress._.noop,
     })
+    if ('yield' in options && !('userYield' in options)) {
+      // remember what the user asked to yield
+      options.userYield = 'value'
+    }
     if (!('initialLimit' in options)) {
       options.initialLimit = options.limit
     }
@@ -115,6 +119,10 @@ function recurse(commandsFn, checkFn, options = {}) {
               options.iteration - 1
             }** after **${elapsedDuration}**`,
           )
+          if (options.userYield === 'value') {
+            // user explicitly asked to yield the value, any value
+            // TODO: return the last value
+          }
           // @ts-ignore
           return cy.state('currentSubject')
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,16 @@ function recurse(commandsFn, checkFn, options = {}) {
 
     // make sure not to modify the passed in options
     options = Cypress._.clone(options)
+
+    if (!('userYield' in options)) {
+      if ('yield' in options) {
+        // remember what the user asked to yield
+        options.userYield = options.yield
+      } else {
+        options.userYield = 'unspecified'
+      }
+    }
+
     Cypress._.defaults(options, RecurseDefaults, {
       // set the started time if not set
       started: now,
@@ -67,10 +77,7 @@ function recurse(commandsFn, checkFn, options = {}) {
       iteration: 1,
       reduce: Cypress._.noop,
     })
-    if ('yield' in options && !('userYield' in options)) {
-      // remember what the user asked to yield
-      options.userYield = 'value'
-    }
+
     if (!('initialLimit' in options)) {
       options.initialLimit = options.limit
     }
@@ -122,6 +129,7 @@ function recurse(commandsFn, checkFn, options = {}) {
           if (options.userYield === 'value') {
             // user explicitly asked to yield the value, any value
             // TODO: return the last value
+            return options.lastValue
           }
           // @ts-ignore
           return cy.state('currentSubject')
@@ -321,6 +329,8 @@ function recurse(commandsFn, checkFn, options = {}) {
             yield: options.yield,
             doNotFail: options.doNotFail,
             initialLimit: options.initialLimit,
+            lastValue: x,
+            userYield: options.userYield,
           })
         }
 


### PR DESCRIPTION
- closes #157 

The yielded value in this case is not guaranteed. You can yield the last value, even if it does not pass the predicate by explicitly asking for it

```js
recurse(
  () => cy.wrap(4),
  (x) => x === 10,
  {
    doNotFail: true,
    yield: 'value',
  },
).should('equal', 4)
```