### PR TITLE
fix: log jQuery better

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,8 +217,14 @@ function recurse(commandsFn, checkFn, options = {}) {
             predicateResult === undefined
 
           if (logCommands) {
-            // @ts-ignore
-            toLog(`value ${String(x)}`)
+            debugger
+            if (Cypress.dom.isJquery(x)) {
+              // @ts-ignore
+              toLog(`jQuery ${x.selector} [${x.length} element]`)
+            } else {
+              // @ts-ignore
+              toLog(`value ${String(x)}`)
+            }
           } else if (typeof options.log === 'function') {
             const elapsed = +new Date() - options.started
             const elapsedDuration = humanizeDuration(elapsed, {


### PR DESCRIPTION
- closes #175 

<img width="374" alt="Screenshot 2023-05-17 at 16 12 07" src="https://github.com/bahmutov/cypress-recurse/assets/2212006/e97f611b-5da6-48e8-b458-80bf212dd0f7">
